### PR TITLE
Added connectors and fixed bottomup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ Manifest.toml
 
 *.sublime-workspace
 *.sublime-project
+
+TODO.md

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -65,4 +65,21 @@ for i in 1:20000
 	global current = current.right
 end
 
-fast_examples = (expr, dict, taproot, my_type, my_complex_type, collider)
+final_collider = Taproot("A final collision", Taproot[])
+first_collider = Taproot("First collider", [
+	Taproot("Go left second", [final_collider]),
+	Taproot("Go right second", [final_collider])
+])
+doubleup = Taproot("Doubleup root", [
+	Taproot("Go left first", [first_collider]),
+	Taproot("Go right first", [first_collider])
+])
+
+different_heights = MoreFlexiTaproot("Top", [
+	MoreFlexiTaproot("A", [
+		MoreFlexiTaproot("Leaf", MoreFlexiTaproot[])
+	]),
+	MoreFlexiTaproot("B", MoreFlexiTaproot[])
+])
+
+fast_examples = (expr, dict, taproot, my_type, my_complex_type, collider, doubleup, different_heights)

--- a/test/traversal.jl
+++ b/test/traversal.jl
@@ -23,6 +23,13 @@ iters = (preorder, postorder, topdown, bottomup, traces, tracepairs)
 	@testset "bottomup" begin
 		collider_bottomup_ans = ["Collider", "Loner", "Go right",  "Go left", "The top"]
 		@test all(bottomup(collider) |> to_compare .== collider_bottomup_ans)
+
+		different_heights_ans = ["B", "Leaf", "A", "Top"]
+		@info "-------------------------------------------------------------"
+		@info "Left hand side = $(bottomup(different_heights) |> to_compare)"
+		@info "Right hand side = $(different_heights_ans)"
+		@info "-------------------------------------------------------------"
+		@test all(bottomup(different_heights) |> to_compare .== different_heights_ans)
 	end
 
 	@testset "leaves" begin
@@ -58,10 +65,10 @@ end
 					push!(lengths, length(collect(iter(taproot))))
 				end
 				valid = length(unique(lengths)) == 1
-				@debug "------------------------------------"
-				@debug "Taproot = $taproot"
-				@debug "Lengths = $(zip(iters, lengths) |> collect)"
-				@debug "------------------------------------"
+				@info "------------------------------------"
+				@info "Taproot = $taproot"
+				@info "Lengths = $(zip(iters, lengths) |> collect)"
+				@info "------------------------------------"
 				if !valid break end
 			end
 			valid
@@ -78,10 +85,10 @@ end
 					push!(lengths, length(collect(iter(taproot; revisit = true))))
 				end
 				valid = length(unique(lengths)) == 1
-				@debug "------------------------------------"
-				@debug "Revisit is set off explicitly. Taproot = $taproot"
-				@debug "Lengths = $(zip(iters, lengths) |> collect)"
-				@debug "------------------------------------"
+				@info "------------------------------------"
+				@info "Revisit is set off explicitly. Taproot = $taproot"
+				@info "Lengths = $(zip(iters, lengths) |> collect)"
+				@info "------------------------------------"
 				if !valid break end
 			end
 			valid
@@ -96,15 +103,16 @@ end
 		@test length(preorder(deepdag) |> collect)	== ans
 	end
 
-	@debug "Starting cycles. If the program hangs, that's a problem"
+	@info "Starting cycles. If the program hangs, that's a problem"
 	@testset "Can handle cycles" begin 
 		for iter in iters
+			@info "Testing $iter"
 			value = 0
 			for (i, v) in enumerate(iter(cycle))
 				value = i
 				if i > 10000 break end
 			end 
-			@test 0 < value <= 100
+			@test 0 <= value <= 100 # 0 allowed for bottomup where there are no leaves
 		end
 	end
 


### PR DESCRIPTION
Added connectors so you can early exit an iterators (and not even bother exploring children nodes).
Also fixed bottomup so that it delays a parent until all children have been processed. 